### PR TITLE
Add ability to change address on PayPal

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform.js
@@ -1,2 +1,3 @@
 //= require spree/frontend/solidus_paypal_commerce_platform/namespace
+//= require spree/frontend/solidus_paypal_commerce_platform/button_actions
 //= require spree/frontend/solidus_paypal_commerce_platform/buttons

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -1,0 +1,54 @@
+SolidusPaypalCommercePlatform.postOrder = function(payment_method_id) {
+  return Spree.ajax({
+    url: '/solidus_paypal_commerce_platform/orders',
+    method: 'POST',
+    data: {
+      payment_method_id: payment_method_id,
+      order_id: Spree.current_order_id,
+      order_token: Spree.current_order_token
+    }
+  }).then(function(res) {
+    return res.table.id;
+  })
+}
+
+SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {
+  actions.order.get().then(function(res){
+    var updated_address = res.purchase_units[0].shipping.address
+    Spree.ajax({
+      url: '/solidus_paypal_commerce_platform/update_address',
+      method: 'POST',
+      data: {
+        address: updated_address,
+        order_id: Spree.current_order_id,
+        order_token: Spree.current_order_token
+      },
+      error: function(response) {
+        message = response.responseJSON;
+        alert('There were some problems with your payment address - ' + message);
+      }
+    }).then(function() {
+      $("#payments_source_paypal_order_id").val(data.orderID)
+      $("#checkout_form_payment").submit()
+    })
+  })
+}
+
+SolidusPaypalCommercePlatform.shippingChange = function(data, actions) {
+  Spree.ajax({
+    url: '/solidus_paypal_commerce_platform/shipping_rates',
+    method: 'GET',
+    data: {
+      order_id: Spree.current_order_id,
+      order_token: Spree.current_order_token,
+      address: data.shipping_address
+    },
+    error: function(response) {
+      message = response.responseJSON;
+      console.log('There were some problems with your payment address - ' + message);
+      actions.reject()
+    }
+  }).then(function(res) {
+    actions.order.patch([res]);
+  });
+}

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -17,6 +17,21 @@ SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) 
     onApprove: function (data, actions) {
       $("#payments_source_paypal_order_id").val(data.orderID)
       $("#checkout_form_payment").submit()
+    },
+    onShippingChange: function(data, actions) {
+      Spree.ajax({
+        url: '/solidus_paypal_commerce_platform/shipping_rates',
+        method: 'GET',
+        data: {
+          order_id: Spree.current_order_id,
+          order_token: Spree.current_order_token,
+          address: data.shipping_address
+        }
+      }).then(function(res) {
+        return actions.order.patch([
+          res
+        ]);
+      });
     }
   }).render('#paypal-button-container')
 }

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -15,8 +15,25 @@ SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) 
       })
     },
     onApprove: function (data, actions) {
-      $("#payments_source_paypal_order_id").val(data.orderID)
-      $("#checkout_form_payment").submit()
+      actions.order.get().then(function(res){
+        var updated_address = res.purchase_units[0].shipping.address
+        return Spree.ajax({
+          url: '/solidus_paypal_commerce_platform/update_address',
+          method: 'POST',
+          data: {
+            address: res.purchase_units[0].shipping.address,
+            order_id: Spree.current_order_id,
+            order_token: Spree.current_order_token
+          },
+          error: function(response) {
+            message = response.responseJSON;
+            alert('There were some problems with your payment address - ' + message);
+          }
+        }).then(function() {
+          $("#payments_source_paypal_order_id").val(data.orderID)
+          $("#checkout_form_payment").submit()
+        })
+      })
     },
     onShippingChange: function(data, actions) {
       Spree.ajax({

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -26,6 +26,11 @@ SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) 
           order_id: Spree.current_order_id,
           order_token: Spree.current_order_token,
           address: data.shipping_address
+        },
+        error: function(response) {
+          message = response.responseJSON;
+          console.log('There were some problems with your payment address - ' + message);
+          actions.reject()
         }
       }).then(function(res) {
         return actions.order.patch([

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -1,59 +1,8 @@
 SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) {
   paypal.Buttons({
     style: style,
-    createOrder: function (data, actions) {
-      return Spree.ajax({
-        url: '/solidus_paypal_commerce_platform/orders',
-        method: 'POST',
-        data: {
-          payment_method_id: payment_method_id,
-          order_id: Spree.current_order_id,
-          order_token: Spree.current_order_token
-        }
-      }).then(function(res) {
-        return res.table.id;
-      })
-    },
-    onApprove: function (data, actions) {
-      actions.order.get().then(function(res){
-        var updated_address = res.purchase_units[0].shipping.address
-        return Spree.ajax({
-          url: '/solidus_paypal_commerce_platform/update_address',
-          method: 'POST',
-          data: {
-            address: res.purchase_units[0].shipping.address,
-            order_id: Spree.current_order_id,
-            order_token: Spree.current_order_token
-          },
-          error: function(response) {
-            message = response.responseJSON;
-            alert('There were some problems with your payment address - ' + message);
-          }
-        }).then(function() {
-          $("#payments_source_paypal_order_id").val(data.orderID)
-          $("#checkout_form_payment").submit()
-        })
-      })
-    },
-    onShippingChange: function(data, actions) {
-      Spree.ajax({
-        url: '/solidus_paypal_commerce_platform/shipping_rates',
-        method: 'GET',
-        data: {
-          order_id: Spree.current_order_id,
-          order_token: Spree.current_order_token,
-          address: data.shipping_address
-        },
-        error: function(response) {
-          message = response.responseJSON;
-          console.log('There were some problems with your payment address - ' + message);
-          actions.reject()
-        }
-      }).then(function(res) {
-        return actions.order.patch([
-          res
-        ]);
-      });
-    }
+    createOrder: SolidusPaypalCommercePlatform.postOrder.bind(null, payment_method_id),
+    onApprove: SolidusPaypalCommercePlatform.approveOrder,
+    onShippingChange: SolidusPaypalCommercePlatform.shippingChange
   }).render('#paypal-button-container')
 }

--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -1,7 +1,7 @@
 module SolidusPaypalCommercePlatform
   class OrdersController < ::Spree::Api::BaseController
     before_action :load_order
-    before_action :load_payment_method
+    before_action :load_payment_method, only: :create
     skip_before_action :authenticate_user
 
     def create
@@ -9,7 +9,22 @@ module SolidusPaypalCommercePlatform
       render json: @payment_method.gateway.create_order(@order, @payment_method.auto_capture), status: :ok
     end
 
+    def update_address
+      authorize! :update, @order, order_token
+      paypal_address = SolidusPaypalCommercePlatform::PaypalAddress.new(@order)
+
+      if paypal_address.update(paypal_address_params)
+        render json: {}, status: :ok
+      else
+        render json: paypal_address.errors.full_messages, status: :unprocessable_entity
+      end
+    end
+
     private
+
+    def paypal_address_params
+      params.require(:address).permit(:address_line_1, :address_line_2, :admin_area_1, :admin_area_2, :postal_code, :country_code)
+    end
 
     def load_order
       @order = Spree::Order.find_by!(number: params[:order_id])

--- a/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
@@ -1,0 +1,20 @@
+module SolidusPaypalCommercePlatform
+  class ShippingRatesController < ::Spree::Api::BaseController
+    before_action :load_order
+    skip_before_action :authenticate_user
+
+    def simulate_shipping_rates
+      authorize! :show, @order, order_token
+      simulated_order = SolidusPaypalCommercePlatform::OrderSimulator.new(@order).simulate_with_address(params[:address])
+      
+      render json: SolidusPaypalCommercePlatform::PaypalOrder.new(simulated_order).to_replace_json, status: :ok
+    end
+
+    private
+
+    def load_order
+      @order = Spree::Order.find_by(number: params[:order_id])
+    end
+
+  end
+end

--- a/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
@@ -7,7 +7,11 @@ module SolidusPaypalCommercePlatform
       authorize! :show, @order, order_token
       simulated_order = SolidusPaypalCommercePlatform::OrderSimulator.new(@order).simulate_with_address(params[:address])
       
-      render json: SolidusPaypalCommercePlatform::PaypalOrder.new(simulated_order).to_replace_json, status: :ok
+      if simulated_order.ship_address.valid?
+        render json: SolidusPaypalCommercePlatform::PaypalOrder.new(simulated_order).to_replace_json, status: :ok
+      else
+        render json: simulated_order.ship_address.errors.full_messages, status: :unprocessable_entity
+      end
     end
 
     private

--- a/app/models/solidus_paypal_commerce_platform/order_simulator.rb
+++ b/app/models/solidus_paypal_commerce_platform/order_simulator.rb
@@ -1,0 +1,66 @@
+module SolidusPaypalCommercePlatform
+  class OrderSimulator
+
+    def initialize(order)
+      @original_order = order
+      @simulated_order = order.dup
+    end
+
+    def simulate_with_address(address)
+      build_address(address)
+      add_line_items
+      create_shipments
+      add_taxes
+      update_totals
+
+      @simulated_order
+    end
+
+    private
+
+    def update_totals
+      @simulated_order.total = @simulated_order.item_total + 
+      @simulated_order.shipment_total + 
+      @simulated_order.adjustments.sum(&:amount) +
+      @simulated_order.additional_tax_total
+    end
+
+    def add_taxes
+      taxes = ::Spree::Config.tax_calculator_class.new(@simulated_order).calculate
+      line_item_taxes = taxes.line_item_taxes.reject(&:included_in_price).sum(&:amount)
+      shipment_taxes = taxes.shipment_taxes.reject(&:included_in_price).sum(&:amount)
+
+      @simulated_order.additional_tax_total = line_item_taxes + shipment_taxes
+    end
+
+    def create_shipments
+      @simulated_order.create_proposed_shipments
+      @simulated_order.shipments.each do |shipment|
+        shipment.cost = shipment.selected_shipping_rate.cost
+      end
+
+      @simulated_order.shipment_total = @simulated_order.shipments.sum(&:amount)
+    end
+
+    def add_line_items
+      @original_order.line_items.each do |line_item|
+        @simulated_order.line_items << line_item.dup
+      end
+    end
+
+    def build_address(address)
+      country = ::Spree::Country.find_by(iso: address[:country_code])
+      # Also adds fake information for a few fields, so validations can run
+      @simulated_order.ship_address = ::Spree::Address.new(
+        city: address[:city],
+        state: country.states.find_by(abbr: address[:state]),
+        state_name: address[:state],
+        zipcode: address[:postal_code],
+        country: country,
+        address1: "123 Fake St.",
+        address2: ""
+      )
+    end
+
+  end
+end

--- a/app/models/solidus_paypal_commerce_platform/order_simulator.rb
+++ b/app/models/solidus_paypal_commerce_platform/order_simulator.rb
@@ -58,7 +58,8 @@ module SolidusPaypalCommercePlatform
         zipcode: address[:postal_code],
         country: country,
         address1: "123 Fake St.",
-        address2: ""
+        phone: "123456789",
+        firstname: "Fake"
       )
     end
 

--- a/app/models/solidus_paypal_commerce_platform/paypal_address.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_address.rb
@@ -1,0 +1,40 @@
+module SolidusPaypalCommercePlatform
+  class PaypalAddress
+    attr_accessor :errors
+
+    def initialize(order)
+      @order = order
+      @errors
+    end
+
+    def update(paypal_address)
+      formatted_address = format_address(paypal_address)
+      new_address = @order.ship_address.dup
+      new_address.assign_attributes(formatted_address)
+
+      if new_address.save
+        @order.update(ship_address_id: new_address.id)
+      else
+        @errors = new_address.errors
+      end
+      
+      new_address
+    end
+
+    private
+
+    def format_address(address)
+      country = ::Spree::Country.find_by(iso: address[:country_code])
+      {
+        address1: address[:address_line_1],
+        address2: address[:address_line_2],
+        state: country.states.find_by(abbr: address[:admin_area_1]) || country.states.find_by(name: address[:admin_area_1]),
+        state_name: address[:admin_area_1],
+        city: address[:admin_area_2],
+        country: country,
+        zipcode: address[:postal_code]
+      }
+    end
+
+  end
+end

--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -9,7 +9,15 @@ module SolidusPaypalCommercePlatform
       return {
         intent: intent,
         purchase_units: purchase_units,
-        payer: payer
+        payer: (payer if @order.bill_address)
+      }
+    end
+
+    def to_replace_json
+      return {
+        op: 'replace',
+        path: '/purchase_units/@reference_id==\'default\'',
+        value: purchase_units[0]
       }
     end
 
@@ -46,7 +54,7 @@ module SolidusPaypalCommercePlatform
         {
           amount: amount,
           items: line_items,
-          shipping: shipping_info
+          shipping: (shipping_info if @order.ship_address)
         }
       ]
     end
@@ -66,7 +74,6 @@ module SolidusPaypalCommercePlatform
         {
           name: line_item.product.name,
           unit_amount: price(line_item.price),
-          tax: price(line_item.included_tax_total / line_item.quantity),
           quantity: line_item.quantity
         }
       }
@@ -84,7 +91,7 @@ module SolidusPaypalCommercePlatform
       {
         item_total: price(@order.item_total),
         shipping: price(@order.shipment_total),
-        tax_total: price(@order.tax_total),
+        tax_total: price(@order.additional_tax_total),
         discount: price(@order.adjustments.sum(&:amount))
       }
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ SolidusPaypalCommercePlatform::Engine.routes.draw do
   resources :orders, only: [:create]
   resources :payments, only: [:create]
   get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"
+  post :update_address, to: "orders#update_address"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ SolidusPaypalCommercePlatform::Engine.routes.draw do
   resources :wizard, only: [:create]
   resources :orders, only: [:create]
   resources :payments, only: [:create]
+  get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"
 end

--- a/spec/models/order_simulator_spec.rb
+++ b/spec/models/order_simulator_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalCommercePlatform::OrderSimulator, type: :model do
+  let(:new_country) { create(:country, iso: "IT") }
+  let(:new_state) { create(:state, country: new_country) }
+  let(:new_address) { create(:address, country: new_country, state: new_state) }
+  let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+  let(:shipping_rate) { create(:shipping_rate, shipping_method: shipping_method) }
+  let(:shipping_method) { create(:shipping_method) }
+  let(:new_tax_rate) { create(:tax_rate, amount: 100, zone: zone) }
+  let(:zone) { create(:zone, name: "Whatever") }
+  let(:paypal_address) {
+    {
+      country_code: new_country.iso,
+      city: new_address.city,
+      state: new_state.abbr,
+      postal_code: new_address.zipcode
+    }
+  }
+
+  describe "#simulate_with_address" do
+    subject{ described_class.new(order).simulate_with_address(paypal_address) }
+
+    before do
+      new_tax_rate
+      new_state
+      zone.countries << new_country
+      zone.shipping_methods = [shipping_method]
+    end
+
+    it "should duplicate the original order" do
+      expect(subject.number).to eq order.number
+      expect(subject.id).to eq nil
+    end
+
+    it "should duplicate original orders line_items" do
+      expected_line_item_array = order.line_items.map{|li| [li.quantity, li.variant_id, li.amount]}
+      expect(subject.line_items.map{ |li| [li.quantity, li.variant_id, li.amount] }).to eq expected_line_item_array
+    end
+
+    it "should replace the shipping address in the duplicated order" do
+      expect(subject.ship_address.state_id).to eq new_state.id
+      expect(subject.ship_address.country_id).to eq new_country.id
+    end
+
+    it "should create a new shipment" do
+      expect(subject.shipments.map(&:number)).to_not eq order.shipments.map(&:number)
+    end
+
+    it "should have the correct shipping method for the new address" do
+      expect(subject.shipments.first.shipping_method).to eq shipping_method
+    end
+
+    it "should create taxes based on the new address" do
+      expected_tax = subject.line_items.sum{|li| li.amount * new_tax_rate.amount}
+      expect(subject.additional_tax_total).to eq expected_tax
+      expect(subject.additional_tax_total).not_to eq order.additional_tax_total
+    end
+
+    it "should display the correct total based on new shipping and taxes" do
+      expect(subject.total).not_to eq order.total
+    end
+  end
+end

--- a/spec/models/paypal_address_spec.rb
+++ b/spec/models/paypal_address_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
+  let(:order) { create(:order_with_line_items, ship_address: original_address) }
+  let(:original_address) { create(:address) }
+  let(:address) { create(:address) }
+
+  describe "#update_address" do
+    subject{ order.ship_address }
+
+    it "should format PayPal addresses correctly" do
+      paypal_address = {
+        admin_area_1: address.state.abbr,
+        admin_area_2: address.city,
+        address_line_1: address.address1,
+        address_line_2: address.address2,
+        postal_code: address.zipcode, 
+        country_code: address.country.iso
+      }
+
+      SolidusPaypalCommercePlatform::PaypalAddress.new(order).update(paypal_address)
+
+      expect(subject.state).to eq address.state
+      expect(subject.city).to eq address.city
+      expect(subject.address1).to eq address.address1
+      expect(subject.address2).to eq address.address2
+      expect(subject.zipcode).to eq address.zipcode
+      expect(subject.country).to eq address.country
+    end
+  end
+end


### PR DESCRIPTION
The star of this PR is the OrderSimulator - which allows us to see what shipping_rates and taxes would be for any particular address.

PayPal only sends us a partial address for the onShippingChange callback, so we don't want to save that address to the order - because if the user decides to use another payment method, they could be stuck with a mismatched address. Instead, we're just simulating what the new totals would be.