### PR TITLE
Add PayPal Button To Cart Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ SolidusPaypalCommercePlatform.partner_id = "xxxxxxxxxxKG2"
 SolidusPaypalCommercePlatform.partner_client_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxVSX"
 ```
 
+Address Phone Number Validation
+-------------------------------
+
+Since PayPal is being used as the checkout if the user checks out on the product or cart page, and PayPal doesn't collect phone numbers, this extension disables phone number required validation for `Spree::Address`. To turn phone number validation back on, you'll need to either:
+
+A) Turn off cart and product page checkout - configurable on the admin payment method page for PayPal Commerce Platform.
+-OR-
+B) Collect the users phone number seperately
+
+and then override the `Spree::Address` method `require_phone?` to return `true`.
+
 Testing
 -------
 

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -7,27 +7,14 @@ SolidusPaypalCommercePlatform.postOrder = function(payment_method_id) {
       order_id: Spree.current_order_id,
       order_token: Spree.current_order_token
     }
-  }).then(function(res) {
-    return res.table.id;
+  }).then(function(response) {
+    return response.table.id;
   })
 }
 
 SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {
-  actions.order.get().then(function(res){
-    var updated_address = res.purchase_units[0].shipping.address
-    Spree.ajax({
-      url: '/solidus_paypal_commerce_platform/update_address',
-      method: 'POST',
-      data: {
-        address: updated_address,
-        order_id: Spree.current_order_id,
-        order_token: Spree.current_order_token
-      },
-      error: function(response) {
-        message = response.responseJSON;
-        alert('There were some problems with your payment address - ' + message);
-      }
-    }).then(function() {
+  actions.order.get().then(function(response){
+    SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
       $("#payments_source_paypal_order_id").val(data.orderID)
       $("#checkout_form_payment").submit()
     })
@@ -48,7 +35,73 @@ SolidusPaypalCommercePlatform.shippingChange = function(data, actions) {
       console.log('There were some problems with your payment address - ' + message);
       actions.reject()
     }
-  }).then(function(res) {
-    actions.order.patch([res]);
+  }).then(function(response) {
+    actions.order.patch([response]);
   });
+}
+
+SolidusPaypalCommercePlatform.finalizeOrder = function(payment_method_id, data, actions) {
+  actions.order.get().then(function(response){
+    SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
+      var paypal_amount = response.purchase_units[0].amount.value
+      SolidusPaypalCommercePlatform.addPayment(paypal_amount, payment_method_id, data).then(function() {
+        SolidusPaypalCommercePlatform.advanceOrder().then(function(response) {
+          window.location.href = SolidusPaypalCommercePlatform.checkout_url
+        })
+      })
+    })
+  })
+}
+
+SolidusPaypalCommercePlatform.advanceOrder = function() {
+  return Spree.ajax({
+    url: '/api/checkouts/' + Spree.current_order_id + '/advance',
+    method: 'PUT',
+    data: {
+      order_token: Spree.current_order_token
+    },
+    error: function(response) {
+      alert('There were some problems with your order');
+    }
+  })
+}
+
+SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_method_id, data) {
+  return Spree.ajax({
+    url: '/api/checkouts/' + Spree.current_order_id + '/payments',
+    method: 'POST',
+    data: {
+      order_token: Spree.current_order_token,
+      payment: {
+        amount: paypal_amount,
+        payment_method_id: payment_method_id,
+        source_attributes: {
+          paypal_order_id: data.orderID
+        }
+      }
+    },
+    error: function(response) {
+      alert('There were some problems with your payment');
+    }
+  })
+}
+
+SolidusPaypalCommercePlatform.updateAddress = function(response) { 
+  var updated_address = response.purchase_units[0].shipping.address
+  return Spree.ajax({
+    url: '/solidus_paypal_commerce_platform/update_address',
+    method: 'POST',
+    data: {
+      address: {
+        updated_address: updated_address,
+        recipient: response.payer
+      },
+      order_id: Spree.current_order_id,
+      order_token: Spree.current_order_token
+    },
+    error: function(response) {
+      message = response.responseJSON;
+      alert('There were some problems with your payment address - ' + message);
+    }
+  })
 }

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -6,3 +6,12 @@ SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) 
     onShippingChange: SolidusPaypalCommercePlatform.shippingChange
   }).render('#paypal-button-container')
 }
+
+SolidusPaypalCommercePlatform.renderCartButton = function(payment_method_id, style) {
+  paypal.Buttons({
+    style: style,
+    createOrder: SolidusPaypalCommercePlatform.postOrder.bind(null, payment_method_id),
+    onApprove: SolidusPaypalCommercePlatform.finalizeOrder.bind(null, payment_method_id),
+    onShippingChange: SolidusPaypalCommercePlatform.shippingChange
+  }).render('#paypal-button-container')
+}

--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -45,11 +45,11 @@ module SolidusPaypalCommercePlatform
     end
 
     def load_order
-      @order = Spree::Order.find_by!(number: params[:order_id])
+      @order = ::Spree::Order.find_by!(number: params[:order_id])
     end
 
     def load_payment_method
-      @payment_method = Spree::PaymentMethod.find(params[:payment_method_id])
+      @payment_method = ::Spree::PaymentMethod.find(params[:payment_method_id])
     end
   end
 end

--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -15,7 +15,7 @@ module SolidusPaypalCommercePlatform
       authorize! :update, @order, order_token
       paypal_address = SolidusPaypalCommercePlatform::PaypalAddress.new(@order)
 
-      if paypal_address.update(paypal_address_params)
+      if paypal_address.update(paypal_address_params).valid?
         render json: {}, status: :ok
       else
         render json: paypal_address.errors.full_messages, status: :unprocessable_entity
@@ -26,12 +26,21 @@ module SolidusPaypalCommercePlatform
 
     def paypal_address_params
       params.require(:address).permit(
-        :address_line_1,
-        :address_line_2,
-        :admin_area_1,
-        :admin_area_2,
-        :postal_code,
-        :country_code,
+        updated_address: [
+          :address_line_1,
+          :address_line_2,
+          :admin_area_1,
+          :admin_area_2,
+          :postal_code,
+          :country_code,
+        ],
+        recipient: [
+          :email_address,
+          name: [
+            :given_name,
+            :surname,
+          ]
+        ]
       )
     end
 

--- a/app/controllers/solidus_paypal_commerce_platform/payments_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/payments_controller.rb
@@ -38,7 +38,7 @@ module SolidusPaypalCommercePlatform
     end
 
     def load_order
-      @order = Spree::Order.find_by!(number: params[:order_id])
+      @order = ::Spree::Order.find_by!(number: params[:order_id])
     end
   end
 end

--- a/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
@@ -20,7 +20,7 @@ module SolidusPaypalCommercePlatform
     private
 
     def load_order
-      @order = Spree::Order.find_by(number: params[:order_id])
+      @order = ::Spree::Order.find_by(number: params[:order_id])
     end
   end
 end

--- a/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
@@ -5,9 +5,9 @@ module SolidusPaypalCommercePlatform
     helper ::Spree::Core::Engine.routes.url_helpers
 
     def create
-      authorize! :create, Spree::PaymentMethod
+      authorize! :create, ::Spree::PaymentMethod
 
-      @payment_method = Spree::PaymentMethod.new(payment_method_params)
+      @payment_method = ::Spree::PaymentMethod.new(payment_method_params)
 
       if @payment_method.save
         edit_url = spree.edit_admin_payment_method_url(@payment_method)

--- a/app/decorators/solidus_paypal_commerce_platform/remove_required_phone_from_address.rb
+++ b/app/decorators/solidus_paypal_commerce_platform/remove_required_phone_from_address.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RemoveRequiredPhoneFromAddress
+  # PayPal doesn't use the phone number, so in cases where the user checks out via
+  # PayPal, this field will be unpopulated. If you want to require phone numbers,
+  # you'll need to turn off cart & product page displays on the payment method edit
+  # page.
+  def require_phone?
+    super && false
+  end
+
+  ::Spree::Address.prepend self
+end

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -9,8 +9,17 @@ module SolidusPaypalCommercePlatform
     preference :paypal_button_size, :paypal_select, default: "responsive"
     preference :paypal_button_shape, :paypal_select, default: "rect"
     preference :paypal_button_layout, :paypal_select, default: "vertical"
+    preference :display_on_cart, :boolean, default: true
 
     def partial_name
+      "paypal_commerce_platform"
+    end
+
+    def display_on_cart
+      preferences[:display_on_cart]
+    end
+
+    def cart_partial_name
       "paypal_commerce_platform"
     end
 

--- a/app/models/solidus_paypal_commerce_platform/wizard.rb
+++ b/app/models/solidus_paypal_commerce_platform/wizard.rb
@@ -28,7 +28,7 @@ module SolidusPaypalCommercePlatform
     private
 
     def logo
-      ActionController::Base.helpers.image_url(Spree::Config[:admin_interface_logo])
+      ActionController::Base.helpers.image_url(::Spree::Config[:admin_interface_logo])
     end
   end
 end

--- a/app/overrides/spree/orders/edit/insert_cart_buttons.rb
+++ b/app/overrides/spree/orders/edit/insert_cart_buttons.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "orders/edit/insert_cart_buttons",
+  virtual_path: "spree/orders/edit",
+  original: "6af87f9fd7740e8f8493c7e8d875690c49fe2adb",
+  insert_after: "[data-hook='cart_items']",
+  partial: 'solidus_paypal_commerce_platform/cart/cart_buttons'
+)

--- a/lib/views/frontend/solidus_paypal_commerce_platform/cart/_cart_buttons.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/cart/_cart_buttons.html.erb
@@ -1,0 +1,3 @@
+<% Spree::PaymentMethod.select{ |payment_method| payment_method.try(:display_on_cart) }.each do |payment_method| %>
+  <%= render partial: "spree/orders/payment/#{payment_method.cart_partial_name}", locals: {payment_method: payment_method} %>
+<% end %>

--- a/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
@@ -1,0 +1,15 @@
+<div style="margin-left:auto;margin-right:auto;width:50%;margin-top:20px;">
+  <script src="<%= payment_method.javascript_sdk_url(order: @order) %>">
+  </script>
+
+  <div id="paypal-button-container"></div>
+
+  <script>
+    Spree.current_order_id = "<%= @order.number %>"
+    Spree.current_order_token = "<%= @order.guest_token %>"
+    SolidusPaypalCommercePlatform.checkout_url = "<%= checkout_url %>"
+    $( document ).ready(function() {
+      SolidusPaypalCommercePlatform.renderCartButton("<%= payment_method.id %>",<%= raw payment_method.button_style.to_json %>)
+    })
+  </script>
+</div>

--- a/spec/features/frontend/cart_spec.rb
+++ b/spec/features/frontend/cart_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe "Cart page" do
+  describe "paypal payment method" do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
+    let(:paypal_payment_method) { create(:paypal_payment_method) }
+
+    before do
+      user = create(:user)
+      order.user = user
+
+      paypal_payment_method
+      allow_any_instance_of(Spree::OrdersController).to receive_messages(
+        current_order: order,
+        try_spree_current_user: user
+      )
+    end
+
+    def paypal_script_options
+      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
+      script_tag_url.query.split('&')
+    end
+
+    it "generate a js file with the correct credentials and intent attached" do
+      visit '/cart'
+      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+    end
+
+    context "when auto-capture is set to true" do
+      it "generate a js file with intent capture" do
+        paypal_payment_method.update(auto_capture: true)
+        visit '/cart'
+        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+        expect(paypal_script_options).to include("intent=capture")
+      end
+    end
+  end
+end

--- a/spec/models/solidus_paypal_commerce_platform/paypal_address_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/paypal_address_spec.rb
@@ -1,24 +1,35 @@
 require 'spec_helper'
 
 RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
-  let(:order) { create(:order_with_line_items, ship_address: original_address) }
+  let(:order) { create(:order) }
   let(:original_address) { create(:address) }
   let(:address) { create(:address) }
-
-  describe "#update_address" do
-    subject{ order.ship_address }
-
-    it "formats PayPal addresses correctly" do
-      paypal_address = {
+  let(:params) {
+    {
+      updated_address: {
         admin_area_1: address.state.abbr,
         admin_area_2: address.city,
         address_line_1: address.address1,
         address_line_2: address.address2,
         postal_code: address.zipcode,
         country_code: address.country.iso
+      },
+      recipient: {
+        name: {
+          given_name: address.firstname,
+          surname: address.lastname
+        }
       }
+    }
+  }
 
-      described_class.new(order).update(paypal_address)
+  describe "#update_address" do
+    subject{ order.ship_address }
+
+    it "formats PayPal addresses correctly" do
+      order.ship_address = original_address
+
+      described_class.new(order).update(params)
 
       expect(subject.state).to eq address.state
       expect(subject.city).to eq address.city
@@ -26,6 +37,19 @@ RSpec.describe SolidusPaypalCommercePlatform::PaypalAddress, type: :model do
       expect(subject.address2).to eq address.address2
       expect(subject.zipcode).to eq address.zipcode
       expect(subject.country).to eq address.country
+      expect(subject.firstname).to eq address.firstname
+      expect(subject.lastname).to eq address.lastname
+      expect(subject.phone).to eq original_address.phone
+    end
+
+    context "when no address exists" do
+      it "produce a valid address" do
+        order.ship_address = nil
+
+        described_class.new(order).update(params)
+
+        expect(subject).to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
~~Depends on #42~~ _merged!_

Adds ability to check out directly from the cart page! 🎉 

The partial that adds the button to the cart page can accept multiple buttons - it's controlled by a `display_on_cart` preference. In the future we may want to move this over to Solidus, if other payment methods are also able to take over for the checkout process. I'll probably handle adding paypal buttons to the product page in a similar way.

Also adds some code that handles cases where an address on the order doesn't exist, and some button actions that handle the PayPal callbacks in a different way than the payments steps paypal button. 

Lastly, this disables the required validation for phone numbers on `Spree::Address`. With solidusio/solidus#3679, it looks like phone numbers might not be required in the future anyway, but also - PayPal doesn't collect phone numbers. Since they are serving as our checkout in this particular checkout flow, so I think it makes sense to disable the required validation.

The other options here are collecting the phone number before or after the user is sent off to PayPal, but that seems unnatural and outside of a normal checkout flow. 

Adds a bit to the README about re-enabling phone number validation if necessary!

Lastly, upon completing the PayPal checkout flow, the user is sent to the confirmation page on Solidus for final confirmation. I've opened #44 to handle cases where the confirmation step doesn't exist, though maybe it should be left up to the user on how to handle that.