### PR TITLE
Add PayPal button to product page

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -1,4 +1,4 @@
-SolidusPaypalCommercePlatform.postOrder = function(payment_method_id) {
+SolidusPaypalCommercePlatform.sendOrder = function(payment_method_id) {
   return Spree.ajax({
     url: '/solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id,
     method: 'GET',
@@ -9,6 +9,56 @@ SolidusPaypalCommercePlatform.postOrder = function(payment_method_id) {
   }).then(function(response) {
     return response.table.id;
   })
+}
+
+SolidusPaypalCommercePlatform.createAndSendOrder = function(payment_method_id) {
+  return SolidusPaypalCommercePlatform.createOrder().then(function(){
+    return SolidusPaypalCommercePlatform.sendOrder(payment_method_id)
+  })
+}
+
+SolidusPaypalCommercePlatform.createOrder = function() {
+  var data = {
+    order: {
+      line_items_attributes: [{
+        variant_id: SolidusPaypalCommercePlatform.getVariantId(),
+        quantity: SolidusPaypalCommercePlatform.getQuantity()
+      }]
+    }
+  }
+
+  return Spree.ajax({
+    url: "/solidus_paypal_commerce_platform/orders",
+    method: 'POST',
+    data: data,
+    error: function(response) {
+      message = response.responseJSON
+      alert('A problem has occurred while creating your order - ' + message);
+    }
+  }).then(function(response) {
+    Spree.current_order_id = response.number
+    Spree.current_order_token = response.guest_token
+  });
+}
+
+SolidusPaypalCommercePlatform.getVariantId = function() {
+  var variants = document.getElementsByName("variant_id")
+  var variant_id;
+  if(variants.length == 1){
+    variant_id = variants[0].value
+  }else{
+    var i;
+    for (i = 0; i < variants.length; i++) {
+      if (variants[i].checked) {
+        variant_id = variants[i].value
+      }
+    }
+  }
+  return variant_id
+}
+
+SolidusPaypalCommercePlatform.getQuantity = function() {
+  return document.getElementById("quantity").value
 }
 
 SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -1,10 +1,9 @@
 SolidusPaypalCommercePlatform.postOrder = function(payment_method_id) {
   return Spree.ajax({
-    url: '/solidus_paypal_commerce_platform/orders',
-    method: 'POST',
+    url: '/solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id,
+    method: 'GET',
     data: {
       payment_method_id: payment_method_id,
-      order_id: Spree.current_order_id,
       order_token: Spree.current_order_token
     }
   }).then(function(response) {

--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/buttons.js
@@ -1,7 +1,7 @@
 SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) {
   paypal.Buttons({
     style: style,
-    createOrder: SolidusPaypalCommercePlatform.postOrder.bind(null, payment_method_id),
+    createOrder: SolidusPaypalCommercePlatform.sendOrder.bind(null, payment_method_id),
     onApprove: SolidusPaypalCommercePlatform.approveOrder,
     onShippingChange: SolidusPaypalCommercePlatform.shippingChange
   }).render('#paypal-button-container')
@@ -10,7 +10,16 @@ SolidusPaypalCommercePlatform.renderButton = function(payment_method_id, style) 
 SolidusPaypalCommercePlatform.renderCartButton = function(payment_method_id, style) {
   paypal.Buttons({
     style: style,
-    createOrder: SolidusPaypalCommercePlatform.postOrder.bind(null, payment_method_id),
+    createOrder: SolidusPaypalCommercePlatform.sendOrder.bind(null, payment_method_id),
+    onApprove: SolidusPaypalCommercePlatform.finalizeOrder.bind(null, payment_method_id),
+    onShippingChange: SolidusPaypalCommercePlatform.shippingChange
+  }).render('#paypal-button-container')
+}
+
+SolidusPaypalCommercePlatform.renderProductButton = function(payment_method_id, style) {
+  paypal.Buttons({
+    style: style,
+    createOrder: SolidusPaypalCommercePlatform.createAndSendOrder.bind(null, payment_method_id),
     onApprove: SolidusPaypalCommercePlatform.finalizeOrder.bind(null, payment_method_id),
     onShippingChange: SolidusPaypalCommercePlatform.shippingChange
   }).render('#paypal-button-container')

--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -2,14 +2,8 @@
 
 module SolidusPaypalCommercePlatform
   class OrdersController < ::Spree::Api::BaseController
-    before_action :load_order
-    before_action :load_payment_method, only: :create
+    before_action :load_order, except: :create
     skip_before_action :authenticate_user
-
-    def create
-      authorize! :update, @order, order_token
-      render json: @payment_method.gateway.create_order(@order, @payment_method.auto_capture), status: :ok
-    end
 
     def update_address
       authorize! :update, @order, order_token
@@ -60,10 +54,6 @@ module SolidusPaypalCommercePlatform
 
     def load_order
       @order = ::Spree::Order.find_by!(number: params[:order_id])
-    end
-
-    def load_payment_method
-      @payment_method = ::Spree::PaymentMethod.find(params[:payment_method_id])
     end
   end
 end

--- a/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/paypal_orders_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusPaypalCommercePlatform
+  class PaypalOrdersController < ::Spree::Api::BaseController
+    before_action :load_payment_method
+    skip_before_action :authenticate_user
+
+    def show
+      authorize! :show, @order, order_token
+      render json: @payment_method.gateway.create_order(@order, @payment_method.auto_capture), status: :ok
+    end
+
+    private
+
+    def load_payment_method
+      @payment_method = ::Spree::PaymentMethod.find(params[:payment_method_id])
+    end
+  end
+end

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -10,6 +10,7 @@ module SolidusPaypalCommercePlatform
     preference :paypal_button_shape, :paypal_select, default: "rect"
     preference :paypal_button_layout, :paypal_select, default: "vertical"
     preference :display_on_cart, :boolean, default: true
+    preference :display_on_product_page, :boolean, default: true
 
     def partial_name
       "paypal_commerce_platform"
@@ -20,6 +21,14 @@ module SolidusPaypalCommercePlatform
     end
 
     def cart_partial_name
+      "paypal_commerce_platform"
+    end
+
+    def display_on_product_page
+      preferences[:display_on_product_page]
+    end
+
+    def product_page_partial_name
       "paypal_commerce_platform"
     end
 
@@ -50,7 +59,7 @@ module SolidusPaypalCommercePlatform
 
     def javascript_sdk_url(order: nil)
       # Both instance and class respond to checkout_steps.
-      step_names = order ? order.checkout_steps : Spree::Order.checkout_steps.keys
+      step_names = order ? order.checkout_steps : ::Spree::Order.checkout_steps.keys
 
       commit_immediately = step_names.include? "confirm"
 

--- a/app/overrides/spree/products/cart_form/insert_product_buttons.rb
+++ b/app/overrides/spree/products/cart_form/insert_product_buttons.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "products/cart_form/insert_product_buttons",
+  virtual_path: "spree/products/_cart_form",
+  insert_bottom: "[data-hook='product_price']",
+  original: '09b5c0504202d92adbfb0f92d6bf12fc17752295',
+  source: :partial,
+  partial: 'solidus_paypal_commerce_platform/product/product_buttons'
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ SolidusPaypalCommercePlatform::Engine.routes.draw do
   # Add your extension routes here
   resources :wizard, only: [:create]
   resources :paypal_orders, only: [:show], param: :order_id
+  resources :orders, only: [:create]
   resources :payments, only: [:create]
   get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"
   post :update_address, to: "orders#update_address"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 SolidusPaypalCommercePlatform::Engine.routes.draw do
   # Add your extension routes here
   resources :wizard, only: [:create]
-  resources :orders, only: [:create]
+  resources :paypal_orders, only: [:show], param: :order_id
   resources :payments, only: [:create]
   get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"
   post :update_address, to: "orders#update_address"

--- a/lib/views/frontend/solidus_paypal_commerce_platform/product/_product_buttons.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/product/_product_buttons.html.erb
@@ -1,0 +1,3 @@
+<% Spree::PaymentMethod.select{ |payment_method| payment_method.try(:display_on_product_page) }.each do |payment_method| %>
+  <%= render partial: "spree/products/payment/#{payment_method.product_page_partial_name}", locals: {payment_method: payment_method} %>
+<% end %>

--- a/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
@@ -1,0 +1,13 @@
+<div style="margin-top:20px;">
+  <script src="<%= payment_method.javascript_sdk_url %>">
+  </script>
+
+  <div id="paypal-button-container"></div>
+
+  <script>
+    SolidusPaypalCommercePlatform.checkout_url = "<%= checkout_url %>"
+    $( document ).ready(function() {
+      SolidusPaypalCommercePlatform.renderProductButton("<%= payment_method.id %>",<%= raw payment_method.button_style.to_json %>)
+    })
+  </script>
+</div>

--- a/spec/features/frontend/product_spec.rb
+++ b/spec/features/frontend/product_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe "Product page", js: true do
+  describe "paypal button" do
+    let(:paypal_payment_method) { create(:paypal_payment_method) }
+    let(:product) { create(:product, variants: [variant, variant_two]) }
+    let(:store) { create(:store) }
+    let(:variant) { create(:variant) }
+    let(:variant_two) { create(:variant) }
+
+    before do
+      paypal_payment_method
+    end
+
+    def paypal_script_options
+      script_tag_url = URI(page.find('script[src*="sdk/js?"]', visible: false)[:src])
+      script_tag_url.query.split('&')
+    end
+
+    it "generates a js file with the correct credentials and intent attached" do
+      visit '/products/' + product.slug
+      expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+    end
+
+    context "when auto-capture is set to true" do
+      it "generates a js file with intent capture" do
+        paypal_payment_method.update(auto_capture: true)
+        visit '/products/' + product.slug
+        expect(paypal_script_options).to include("client-id=#{paypal_payment_method.preferences[:client_id]}")
+        expect(paypal_script_options).to include("intent=capture")
+      end
+    end
+
+    describe "order creation" do
+      before do
+        allow_any_instance_of(Spree::Core::ControllerHelpers::Store).to receive(:current_store) { store }
+        visit '/products/' + product.slug
+
+        # Stubbing out paypal methods since their JS doesn't load in correctly on tests
+        page.execute_script("paypal = {}")
+        page.execute_script("paypal.render = function(){}")
+        page.execute_script("paypal.Buttons = function(){return paypal}")
+
+        # Waiting until the paypal button becomes available, because the SPCP namespace
+        # isn't immediately available
+        page.find("#paypal-button-container")
+      end
+
+      it "creates an order successfully" do
+        page.evaluate_script("SolidusPaypalCommercePlatform.createOrder()")
+
+        expect(Spree::Order.last).not_to be nil
+      end
+
+      it "sets the Spree number and token variables" do
+        page.evaluate_script("SolidusPaypalCommercePlatform.createOrder()")
+
+        expect(page.evaluate_script("Spree.current_order_id")).to eq Spree::Order.last.number
+        expect(page.evaluate_script("Spree.current_order_token")).to eq Spree::Order.last.guest_token
+      end
+
+      it "uses the specified quantity" do
+        quantity = 12
+        fill_in('quantity', with: quantity)
+
+        page.evaluate_script("SolidusPaypalCommercePlatform.createOrder()")
+
+        expect(Spree::Order.last.line_items.first.quantity).to eq quantity
+      end
+
+      it "uses the selected variant" do
+        page.choose("variant_id_#{variant_two.id}")
+        page.evaluate_script("SolidusPaypalCommercePlatform.createOrder()")
+
+        expect(Spree::Order.last.line_items.first.variant_id).to eq variant_two.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
Depends on ~~#43 and #42~~ _merged_ 😬 

- [x] Renames orders_controller `create` action to `show` to be more inline with what it does
- [x] Creates a new create action for orders_controller that actually creates a new order for the user
- [x] Add button and button action JS for the product page
- [x] Add preference to determine if the product page displays the PayPal button
- [x] Add deface/views to add PayPal button to product page, similar to how the cart button is displayed

Fixes #27 