### PR TITLE
Add configuration options to SolidusPaypalCommercePlatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ B) Collect the users phone number seperately
 
 and then override the `Spree::Address` method `require_phone?` to return `true`.
 
+Customization
+-------------
+
+You can customize some of the settings in this app with the `configure` 
+method in an initializer. For instance, if you'd prefer to use your own order
+simulator to simulate taxes & shipping rates from a custom address, you can set
+the order_simulator_class like this:
+
+```ruby
+# config/initializers/use_my_simulator.rb
+
+SolidusPaypalCommercePlatform.configure do |config|
+  config.order_simulator_class = "MyApp::MyOrderSimulator"
+end
+```
+
 Testing
 -------
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,13 @@ bundle exec rails g solidus_paypal_commerce_platform:install
 
 This extension will automatically selecte a PayPal environment based on Rails environment so that "production" will be mapped to the "live" PayPal environment, and everything else will be routed to the "sandbox" PayPal environment.
 
-If you want to override these values you can either set `SolidusPaypalCommercePlatform.env` to `"live"` or `"sandbox"` inside an initializer. Or, alternatively, you can set the `PAYPAL_ENV` environment variable to one of the same two values.
+If you want to override these values you can either set `SolidusPaypalCommercePlatform.config.env` to `"live"` or `"sandbox"` inside an initializer. Or, alternatively, you can set the `PAYPAL_ENV` environment variable to one of the same two values.
 
 ### Custom PartnerID, PartnerClientID, and Nonce
 
 You can declare your PayPal Partner-ID and Partner-Client-ID as environment
-variables or set their values directly on `SolidusPaypalCommercePlatform`.
+variables or set their values directly on `SolidusPaypalCommercePlatform.config`
+or by using the configuration method detailed in the Customization section.
 
 #### Use ENV variables
 
@@ -96,9 +97,9 @@ export PAYPAL_PARTNER_CLIENT_ID="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #### Set them directly
 
 ```ruby
-SolidusPaypalCommercePlatform.nonce = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxbdb84"
-SolidusPaypalCommercePlatform.partner_id = "xxxxxxxxxxKG2"
-SolidusPaypalCommercePlatform.partner_client_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxVSX"
+SolidusPaypalCommercePlatform.config.nonce = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxbdb84"
+SolidusPaypalCommercePlatform.config.partner_id = "xxxxxxxxxxKG2"
+SolidusPaypalCommercePlatform.config.partner_client_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxVSX"
 ```
 
 Address Phone Number Validation

--- a/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/shipping_rates_controller.rb
@@ -7,7 +7,7 @@ module SolidusPaypalCommercePlatform
 
     def simulate_shipping_rates
       authorize! :show, @order, order_token
-      order_simulator = SolidusPaypalCommercePlatform::OrderSimulator.new(@order)
+      order_simulator = SolidusPaypalCommercePlatform.config.order_simulator_class.new(@order)
       simulated_order = order_simulator.simulate_with_address(params[:address])
 
       if simulated_order.ship_address.valid?

--- a/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
@@ -31,7 +31,7 @@ module SolidusPaypalCommercePlatform
         type: SolidusPaypalCommercePlatform::PaymentMethod,
         preferred_client_id: api_credentials.client_id,
         preferred_client_secret: api_credentials.client_secret,
-        preferred_test_mode: SolidusPaypalCommercePlatform.env.sandbox?
+        preferred_test_mode: SolidusPaypalCommercePlatform.config.env.sandbox?
       }
     end
 

--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -72,7 +72,7 @@ module SolidusPaypalCommercePlatform
 
       @client.execute(FetchMerchantCredentialsRequest.new(
         access_token: access_token,
-        partner_merchant_id: SolidusPaypalCommercePlatform.partner_id,
+        partner_merchant_id: SolidusPaypalCommercePlatform.config.partner_id,
       )).result
     end
 

--- a/app/models/solidus_paypal_commerce_platform/wizard.rb
+++ b/app/models/solidus_paypal_commerce_platform/wizard.rb
@@ -13,16 +13,16 @@ module SolidusPaypalCommercePlatform
     def button_url
       parameters = {
         product: "addipmt",
-        partnerId: SolidusPaypalCommercePlatform.partner_id,
-        partnerClientId: SolidusPaypalCommercePlatform.partner_client_id,
+        partnerId: SolidusPaypalCommercePlatform.config.partner_id,
+        partnerClientId: SolidusPaypalCommercePlatform.config.partner_client_id,
         features: "PAYMENT,REFUND",
         partnerLogoUrl: logo,
         integrationType: "FO",
         displayMode: "minibrowser",
-        sellerNonce: SolidusPaypalCommercePlatform.nonce
+        sellerNonce: SolidusPaypalCommercePlatform.config.nonce
       }
 
-      URI("https://#{SolidusPaypalCommercePlatform.env_domain}/bizsignup/partner/entry?#{parameters.to_query}")
+      URI("https://#{SolidusPaypalCommercePlatform.config.env_domain}/bizsignup/partner/entry?#{parameters.to_query}")
     end
 
     private

--- a/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_paypal_wizard.html.erb
+++ b/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_paypal_wizard.html.erb
@@ -8,9 +8,9 @@
     <%= t('sign_up_for_paypal') %>
   </button>
 </a>
-<script id="paypal-js" src="https://<%= SolidusPaypalCommercePlatform.env_domain %>/webapps/merchantboarding/js/lib/lightbox/partner.js"></script>
+<script id="paypal-js" src="https://<%= SolidusPaypalCommercePlatform.config.env_domain %>/webapps/merchantboarding/js/lib/lightbox/partner.js"></script>
 
 <script>
-  window.SolidusPaypalCommercePlatform.nonce = "<%= SolidusPaypalCommercePlatform.nonce %>"
+  window.SolidusPaypalCommercePlatform.nonce = "<%= SolidusPaypalCommercePlatform.config.nonce %>"
   window.SolidusPaypalCommercePlatform_onboardCallback = SolidusPaypalCommercePlatform.onboardCallback
 </script>

--- a/lib/solidus_paypal_commerce_platform.rb
+++ b/lib/solidus_paypal_commerce_platform.rb
@@ -4,6 +4,6 @@ require 'solidus_core'
 require 'solidus_support'
 
 require 'solidus_paypal_commerce_platform/version'
-require 'solidus_paypal_commerce_platform/environment'
+require 'solidus_paypal_commerce_platform/configuration'
 require 'solidus_paypal_commerce_platform/client'
 require 'solidus_paypal_commerce_platform/engine'

--- a/lib/solidus_paypal_commerce_platform.rb
+++ b/lib/solidus_paypal_commerce_platform.rb
@@ -7,3 +7,15 @@ require 'solidus_paypal_commerce_platform/version'
 require 'solidus_paypal_commerce_platform/configuration'
 require 'solidus_paypal_commerce_platform/client'
 require 'solidus_paypal_commerce_platform/engine'
+
+module SolidusPaypalCommercePlatform
+  class << self
+    def config
+      @config ||= Configuration.new
+    end
+
+    def configure
+      yield config
+    end
+  end
+end

--- a/lib/solidus_paypal_commerce_platform/client.rb
+++ b/lib/solidus_paypal_commerce_platform/client.rb
@@ -13,7 +13,7 @@ module SolidusPaypalCommercePlatform
     attr_reader :environment
 
     def initialize(test_mode: nil, client_id:, client_secret: "")
-      test_mode = SolidusPaypalCommercePlatform.env.sandbox? if test_mode.nil?
+      test_mode = SolidusPaypalCommercePlatform.config.env.sandbox? if test_mode.nil?
       env_class = test_mode ? PayPal::SandboxEnvironment : PayPal::LiveEnvironment
 
       @environment = env_class.new(client_id, client_secret)

--- a/lib/solidus_paypal_commerce_platform/configuration.rb
+++ b/lib/solidus_paypal_commerce_platform/configuration.rb
@@ -3,7 +3,7 @@
 require 'paypal-checkout-sdk'
 
 module SolidusPaypalCommercePlatform
-  module Environment
+  class Configuration
     InvalidEnvironment = Class.new(StandardError)
 
     DEFAULT_NONCE = {
@@ -70,6 +70,4 @@ module SolidusPaypalCommercePlatform
       @partner_client_id ||= ENV['PAYPAL_PARTNER_CLIENT_ID'] || DEFAULT_PARTNER_CLIENT_ID[env.to_sym]
     end
   end
-
-  extend Environment
 end

--- a/lib/solidus_paypal_commerce_platform/configuration.rb
+++ b/lib/solidus_paypal_commerce_platform/configuration.rb
@@ -4,6 +4,7 @@ require 'paypal-checkout-sdk'
 
 module SolidusPaypalCommercePlatform
   class Configuration
+    attr_writer :order_simulator_class
     InvalidEnvironment = Class.new(StandardError)
 
     DEFAULT_NONCE = {
@@ -20,6 +21,12 @@ module SolidusPaypalCommercePlatform
       sandbox: "ATDpQjHzjCz_C_qbbJ76Ca0IjcmwlS4FztD6YfuRFZXDCmcWWw8-8QWcF3YIkbC85ixTUuuSEvrBMVSX",
       live: "TBD",
     }.freeze
+
+    def order_simulator_class
+      self.order_simulator_class = "SolidusPaypalCommercePlatform::OrderSimulator" unless @order_simulator_class
+
+      @order_simulator_class.constantize
+    end
 
     def env=(value)
       unless %w[live sandbox].include? value

--- a/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
+++ b/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-RSpec.describe SolidusPaypalCommercePlatform::Environment do
-  let(:subject) { Class.new.extend described_class }
+RSpec.describe SolidusPaypalCommercePlatform::Configuration do
+  let(:subject) { described_class.new }
 
   describe '#default_env' do
     it "uses ENV['PAYPAL_ENV'] when present" do

--- a/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
+++ b/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
@@ -64,4 +64,22 @@ RSpec.describe SolidusPaypalCommercePlatform::Configuration do
       expect(subject.env_domain).to eq("www.sandbox.paypal.com")
     end
   end
+
+  describe "#order_simulator_class" do
+    before do
+      stub_const('SolidusPaypalCommercePlatform::BetterOrderSimulator', Class.new)
+    end
+
+    it "returns a class" do
+      expect(subject.order_simulator_class).to be_kind_of(Class)
+    end
+
+    it "is settable" do
+      expect(subject.order_simulator_class).to eq(SolidusPaypalCommercePlatform::OrderSimulator)
+
+      subject.order_simulator_class = "SolidusPaypalCommercePlatform::BetterOrderSimulator"
+
+      expect(subject.order_simulator_class).to eq(SolidusPaypalCommercePlatform::BetterOrderSimulator)
+    end
+  end
 end


### PR DESCRIPTION
Adds ability to configure SPCP with:
```ruby
SolidusPaypalCommercePlatform.configure do |config|
  config.order_simulator_class = "MyApp::BetterOrderSimulator"
end
```
instead of just setting options directly onto SolidusPaypalCommercePlatform. Also makes order_simulator a customizable class to solve #36 