### PR TITLE
Add PayPal Debug ID to log entries

### DIFF
--- a/app/overrides/spree/admin/payments/log_entries/add_paypal_debug_id.rb
+++ b/app/overrides/spree/admin/payments/log_entries/add_paypal_debug_id.rb
@@ -1,0 +1,7 @@
+Deface::Override.new(
+  name: "payments/log_entries/add_paypal_debug_id",
+  virtual_path: "spree/admin/payments/_log_entries",
+  original: "5eb2952fa4ba1484a63e5abf53e4ed735761a7b2",
+  replace: "#listing_log_entries",
+  partial: "solidus_paypal_commerce_platform/admin/payments/log_entries"
+)

--- a/app/views/solidus_paypal_commerce_platform/admin/payments/_log_entries.html.erb
+++ b/app/views/solidus_paypal_commerce_platform/admin/payments/_log_entries.html.erb
@@ -1,0 +1,32 @@
+<table class='index' id='listing_log_entries'>
+  <colgroup>
+    <col style="width: 30%" />
+    <col style="width: 40%" />
+    <col style="width: 20%" />
+    <col style="width: 10%" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th><%= Spree::LogEntry.human_attribute_name(:created_at) %></th>
+      <th><%= Spree::LogEntry.human_attribute_name(:details) %></th>
+      <th><%= I18n.t("paypal_debug_id") %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  <% log_entries.each do |entry| %>
+    <tr class="log_entry <%= entry.parsed_details.success? ? 'success' : 'fail' %>">
+      <td>
+        <%= pretty_time(entry.created_at) %>
+      </td>
+      <td>
+        <pre><%= entry.parsed_details.message %></pre>
+      </td>
+      <td><%= entry.parsed_details.params["paypal_debug_id"] %></td>
+      <td class="text-right">
+        <i class='fa fa-<%= entry.parsed_details.success? ? 'check' : 'remove' %>'></i>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   sign_up_for_paypal: Setup PayPal Commerce Platform
   start_paying_with_paypal: Start paying with Paypal Commerce Platform
   paypal_order_id: PayPal Order ID
+  paypal_debug_id: PayPal Debug ID
   virtual_terminal_notice_html: Backend Credit Card payments can only be accepted through PayPal via the <a href="https://www.paypal.com/merchantapps/appcenter/acceptpayments/virtualterminal">PayPal Virtual Terminal</a>.
   solidus_paypal_commerce_platform:
     responses:

--- a/lib/solidus_paypal_commerce_platform/client.rb
+++ b/lib/solidus_paypal_commerce_platform/client.rb
@@ -44,7 +44,7 @@ module SolidusPaypalCommercePlatform
     def wrap_response(response, success_message: nil, failure_message: nil)
       if SUCCESS_STATUS_CODES.include? response.status_code
         success_message ||= "Success."
-        ActiveMerchant::Billing::Response.new(true, success_message, result: response.result)
+        ActiveMerchant::Billing::Response.new(true, success_message, result: response.result, paypal_debug_id: response.headers["paypal-debug-id"])
       else
         failure_message ||= "A problem has occurred with this payment, please try again."
         ActiveMerchant::Billing::Response.new(false, failure_message)

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SolidusPaypalCommercePlatform::Client do
   describe '#execute_with_response' do
     let(:request_class) { SolidusPaypalCommercePlatform::Gateway::OrdersCaptureRequest }
     let(:paypal_request) { double(:request, class: request_class) }
-    let(:paypal_response) { double(:response, status_code: status_code, result: nil) }
+    let(:paypal_response) { double(:response, status_code: status_code, result: nil, headers: {}) }
     let(:status_code) { 201 }
 
     before do

--- a/spec/models/payment_method_spec.rb
+++ b/spec/models/payment_method_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
             )
           )
         ]
-      )
+      ),
+      headers: {
+        "paypal-debug-id": ["123"]
+      }
     )
 
     allow_any_instance_of(PayPal::PayPalHttpClient).to receive(:execute) { response }


### PR DESCRIPTION
PayPal wants us to store a debug ID for each request. This stores it
in the ActiveRecord::Billing::Response object and displays it on the
log entries section of the admin payments show page. ref: #48 