### PR TITLE
Display paypal email to customer on confirmation

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -16,6 +16,7 @@ SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {
   actions.order.get().then(function(response){
     SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
       $("#payments_source_paypal_order_id").val(data.orderID)
+      $("#payments_source_paypal_email").val(response.payer.email_address)
       $("#checkout_form_payment").submit()
     })
   })
@@ -44,7 +45,7 @@ SolidusPaypalCommercePlatform.finalizeOrder = function(payment_method_id, data, 
   actions.order.get().then(function(response){
     SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
       var paypal_amount = response.purchase_units[0].amount.value
-      SolidusPaypalCommercePlatform.addPayment(paypal_amount, payment_method_id, data).then(function() {
+      SolidusPaypalCommercePlatform.addPayment(paypal_amount, payment_method_id, data, response.payer.email_address).then(function() {
         SolidusPaypalCommercePlatform.advanceOrder().then(function(response) {
           window.location.href = SolidusPaypalCommercePlatform.checkout_url
         })
@@ -66,7 +67,7 @@ SolidusPaypalCommercePlatform.advanceOrder = function() {
   })
 }
 
-SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_method_id, data) {
+SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_method_id, data, email) {
   return Spree.ajax({
     url: '/api/checkouts/' + Spree.current_order_id + '/payments',
     method: 'POST',
@@ -76,7 +77,8 @@ SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_metho
         amount: paypal_amount,
         payment_method_id: payment_method_id,
         source_attributes: {
-          paypal_order_id: data.orderID
+          paypal_order_id: data.orderID,
+          paypal_email: email
         }
       }
     },

--- a/app/overrides/spree/payments/payment/add_paypal_email_to_payment.rb
+++ b/app/overrides/spree/payments/payment/add_paypal_email_to_payment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "payments/payment/add_paypal_email_to_payment",
+  virtual_path: "spree/payments/_payment",
+  original: "0b5b5ae53626059cb3a202ef95d10827dd399925",
+  insert_after: "erb[loud]:contains('content_tag(:span, payment.payment_method.name)')",
+  partial: "solidus_paypal_commerce_platform/payments/payment"
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
   start_paying_with_paypal: Start paying with Paypal Commerce Platform
   paypal_order_id: PayPal Order ID
   paypal_debug_id: PayPal Debug ID
+  paypal_email: PayPal Email
+  payment_email: "Payment Email: %{email}"
   virtual_terminal_notice_html: Backend Credit Card payments can only be accepted through PayPal via the <a href="https://www.paypal.com/merchantapps/appcenter/acceptpayments/virtualterminal">PayPal Virtual Terminal</a>.
   solidus_paypal_commerce_platform:
     responses:

--- a/db/migrate/20200702122528_add_email_to_paypal_commerce_platform_sources.rb
+++ b/db/migrate/20200702122528_add_email_to_paypal_commerce_platform_sources.rb
@@ -1,0 +1,5 @@
+class AddEmailToPaypalCommercePlatformSources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :paypal_commerce_platform_sources, :paypal_email, :string
+  end
+end

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -14,7 +14,7 @@ module SolidusPaypalCommercePlatform
     initializer "solidus_paypal_commerce_platform.add_payment_method", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalCommercePlatform::PaymentMethod
       SolidusPaypalCommercePlatform::PaymentMethod.allowed_admin_form_preference_types << :paypal_select
-      Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id]
+      Spree::PermittedAttributes.source_attributes.concat [:paypal_order_id, :authorization_id, :paypal_email]
     end
 
     initializer "solidus_paypal_commerce_platform.add_wizard", after: "spree.register.payment_methods" do |app|

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_commerce_platform.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_commerce_platform.html.erb
@@ -9,6 +9,9 @@
 
         <dt><%= I18n.t("paypal_order_id") %>:</dt>
         <dd><%= payment.source.paypal_order_id %></dd>
+
+        <dt><%= I18n.t("paypal_email") %>:</dt>
+        <dd><%= payment.source.paypal_email %></dd>
       </dl>
     </div>
   </div>

--- a/lib/views/frontend/solidus_paypal_commerce_platform/payments/_payment.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/payments/_payment.html.erb
@@ -1,0 +1,4 @@
+<% if payment.source.respond_to?(:paypal_email) %>
+  <br />
+  <%= t('payment_email', email: payment.source.paypal_email) %>
+<% end %>

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -2,6 +2,7 @@
 
 <div id="paypal-button-container"></div>
 <input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_order_id]" id="payments_source_paypal_order_id">
+<input type="hidden" name="payment_source[<%= payment_method.id %>][paypal_email]" id="payments_source_paypal_email">
 
 <script>
   $( document ).ready(function() {

--- a/spec/features/frontend/checkout_spec.rb
+++ b/spec/features/frontend/checkout_spec.rb
@@ -52,6 +52,15 @@ RSpec.describe "Checkout" do
         click_button("Save and Continue")
         expect(page).to have_css(".current", text: "Confirm")
       end
+
+      it "records the paypal email address" do
+        visit '/checkout/payment'
+        choose(option: paypal_payment_method.id)
+        find(:xpath, "//input[@id='payments_source_paypal_order_id']", visible: false).set SecureRandom.hex(8)
+        find(:xpath, "//input[@id='payments_source_paypal_email']", visible: false).set "fake@email.com"
+        click_button("Save and Continue")
+        expect(Spree::Payment.last.source.paypal_email).to eq "fake@email.com"
+      end
     end
   end
 end


### PR DESCRIPTION
As #47 states, we need to display the users paypal email to the customer on the confirmation page. This handles that! Also, displays the paypal_email to admin users as well, since that could come in handy.