### PR TITLE
Verify amount to charge with order total

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -22,7 +22,21 @@ module SolidusPaypalCommercePlatform
       end
     end
 
+    def verify_total
+      authorize! :show, @order, order_token
+
+      if total_is_correct?(params[:paypal_total])
+        render json: {}, status: :ok
+      else
+        respond_with(@order, default_template: 'spree/api/orders/expected_total_mismatch', status: 400)
+      end
+    end
+
     private
+
+    def total_is_correct?(paypal_total)
+      @order.outstanding_balance == BigDecimal(paypal_total)
+    end
 
     def paypal_address_params
       params.require(:address).permit(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ SolidusPaypalCommercePlatform::Engine.routes.draw do
   resources :payments, only: [:create]
   get :shipping_rates, to: "shipping_rates#simulate_shipping_rates"
   post :update_address, to: "orders#update_address"
+  get :verify_total, to: "orders#verify_total"
 end

--- a/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
+++ b/spec/requests/solidus_paypal_commerce_platform/orders_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalCommercePlatform::OrdersController, type: :request do
+  stub_authorization!
+  let(:order) { create(:order_with_line_items) }
+
+  describe "GET /solidus_paypal_commerce_platform/verify_total" do
+    context "when the amount is correct" do
+      it "passes" do
+        params = {
+          order_id: order.number,
+          paypal_total: order.total,
+          format: :json
+        }
+
+        get solidus_paypal_commerce_platform.verify_total_path, params: params
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context "when the amount is incorrect" do
+      it "fails" do
+        params = {
+          order_id: order.number,
+          paypal_total: order.total - 1,
+          format: :json
+        }
+
+        get solidus_paypal_commerce_platform.verify_total_path, params: params
+
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to be able to verify that the amount we receive from PayPal
equals the outstanding balance of the order. So, this adds an API
endpoint that allows us to verify that, and sends the amount PayPal
says is due there for verification. 

Also fixes an issue with the cart checkout - moving the advanceOrder
function to a more sensible location.

ref: #37 