### PR TITLE
Send amount of payment to PayPal on capture

### DIFF
--- a/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/payment_method_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
     it "sends a purchase request to paypal" do
       paypal_order_id = SecureRandom.hex(8)
       source = paypal_payment_method.payment_source_class.create(paypal_order_id: paypal_order_id)
-      expect_request(:OrdersCaptureRequest).to receive(:new).with(paypal_order_id)
+      expect_request(:OrdersCaptureRequest).to receive(:new).with(paypal_order_id).and_call_original
       paypal_payment_method.purchase(1000, source, {})
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe SolidusPaypalCommercePlatform::PaymentMethod, type: :model do
       authorization_id = SecureRandom.hex(8)
       source = paypal_payment_method.payment_source_class.create(authorization_id: authorization_id)
       payment.source = source
-      expect_request(:AuthorizationsCaptureRequest).to receive(:new).with(authorization_id)
+      expect_request(:AuthorizationsCaptureRequest).to receive(:new).with(authorization_id).and_call_original
       paypal_payment_method.capture(1000, {}, originator: payment)
     end
   end


### PR DESCRIPTION
Previously, we were just telling PayPal to capture the amount that
was authorized. However, admin users have the ability to edit the
amount of the payment, so now we're sending the amount of the payment
to PayPal for capturing.

You can capture less than the authorized amount just fine, however
trying to capture MORE than that amount will fail the payment and
flash a "Something went wrong" error. I think that's fine for the
functionality we want - I would expect to not be able to charge
more than the customer authorized.

Should fix #29