### PR TITLE
Verify email address is verified before allowing payment method to be available

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
@@ -31,7 +31,9 @@ module SolidusPaypalCommercePlatform
         type: SolidusPaypalCommercePlatform::PaymentMethod,
         preferred_client_id: api_credentials.client_id,
         preferred_client_secret: api_credentials.client_secret,
-        preferred_test_mode: SolidusPaypalCommercePlatform.config.env.sandbox?
+        preferred_test_mode: SolidusPaypalCommercePlatform.config.env.sandbox?,
+        available_to_users: false,
+        available_to_admin: false
       }
     end
 

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -11,6 +11,7 @@ module SolidusPaypalCommercePlatform
     preference :paypal_button_layout, :paypal_select, default: "vertical"
     preference :display_on_cart, :boolean, default: true
     preference :display_on_product_page, :boolean, default: true
+    preference :paypal_email_confirmed, :boolean, default: false
 
     def partial_name
       "paypal_commerce_platform"

--- a/app/overrides/spree/admin/payment_methods/form/insert_email_verification_notification.rb
+++ b/app/overrides/spree/admin/payment_methods/form/insert_email_verification_notification.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Deface::Override.new(
+  name: "payment_methods/form/insert_email_verification_notification",
+  virtual_path: "spree/admin/payment_methods/_form",
+  original: "471a995989ea93a58118c80be38fafcd1fd3ee69",
+  replace: "erb[loud]:contains('f.check_box :available_to_users')",
+  partial: "solidus_paypal_commerce_platform/admin/payment_methods/available_to_users"
+)

--- a/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
+++ b/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
@@ -1,0 +1,6 @@
+<% if @payment_method.type == "SolidusPaypalCommercePlatform::PaymentMethod" && !@payment_method.preferences[:paypal_email_confirmed] %>
+  <%= f.check_box :available_to_users, disabled: true %>
+  <%= f.field_hint :available_to_users %>
+<% else %>
+  <%= f.check_box :available_to_users %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 en:
   spree:
+    hints:
+      solidus_paypal_commerce_platform/payment_method:
+        available_to_users: You must verify that your email is confirmed with PayPal before allowing users to check out.
     payment_source: source
   activerecord:
     attributes:


### PR DESCRIPTION
We want to ensure that the users PayPal email is verified before
accepting payments with this payment_method, so we're defaulting
payment method availability to false and requiring the user to verify
that their email is confirmed before allowing the payment_method
to be available to users.

![image](https://user-images.githubusercontent.com/5720486/87465118-c6140f80-c5d9-11ea-9285-fd02f2d9da6e.png)

Fixes #9 