### PR TITLE
Explicitly require deface

### DIFF
--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'deface'
 require 'spree/core'
 require 'solidus_paypal_commerce_platform'
 


### PR DESCRIPTION
It's not being picked up automatically because Bundler.require within
the rails app will only require gems listed in its gemfile.