### PR TITLE
Only use available payment_methods

### DIFF
--- a/lib/views/frontend/solidus_paypal_commerce_platform/cart/_cart_buttons.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/cart/_cart_buttons.html.erb
@@ -1,3 +1,3 @@
-<% Spree::PaymentMethod.select{ |payment_method| payment_method.try(:display_on_cart) }.each do |payment_method| %>
+<% Spree::PaymentMethod.available_to_users.select{ |payment_method| payment_method.try(:display_on_cart) }.each do |payment_method| %>
   <%= render partial: "spree/orders/payment/#{payment_method.cart_partial_name}", locals: {payment_method: payment_method} %>
 <% end %>

--- a/lib/views/frontend/solidus_paypal_commerce_platform/product/_product_buttons.html.erb
+++ b/lib/views/frontend/solidus_paypal_commerce_platform/product/_product_buttons.html.erb
@@ -1,3 +1,3 @@
-<% Spree::PaymentMethod.select{ |payment_method| payment_method.try(:display_on_product_page) }.each do |payment_method| %>
+<% Spree::PaymentMethod.available_to_users.select{ |payment_method| payment_method.try(:display_on_product_page) }.each do |payment_method| %>
   <%= render partial: "spree/products/payment/#{payment_method.product_page_partial_name}", locals: {payment_method: payment_method} %>
 <% end %>


### PR DESCRIPTION
Previously we were not checking if the payment methods were available
to users in these overrides, meaning that SPCP would always show up
regardless of the `available_to_users` flag.