### PR TITLE
Include payment method information in pricing options cache key

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/pricing_options.rb
+++ b/app/models/solidus_paypal_commerce_platform/pricing_options.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SolidusPaypalCommercePlatform
+  class PricingOptions < Spree::Variant::PricingOptions
+    def cache_key
+      SolidusPaypalCommercePlatform::PaymentMethod.active.map(&:cache_key).sort + [super]
+    end
+  end
+end

--- a/lib/solidus_paypal_commerce_platform/engine.rb
+++ b/lib/solidus_paypal_commerce_platform/engine.rb
@@ -24,6 +24,12 @@ module SolidusPaypalCommercePlatform
       app.config.spree.payment_setup_wizards << "SolidusPaypalCommercePlatform::Wizard"
     end
 
+    initializer "solidus_paypal_commerce_platform.set_pricing_options_class" do
+      def (Spree::Config).pricing_options_class
+        SolidusPaypalCommercePlatform::PricingOptions
+      end
+    end
+
     # use rspec for tests
     config.generators do |g|
       g.test_framework :rspec


### PR DESCRIPTION
The cache for products needs to be expired when the paypal commerce platform
payment method is changed, deleted, or updated - since it displays a button
on the product page. This adds a custom pricing_options_class - which just
updates the cache_key to include SPCP payment method information. Thanks
to @elia for actually doing this work - I just adapted it to this extension.
🙏 