### PR TITLE
Add version to cache_key

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/pricing_options.rb
+++ b/app/models/solidus_paypal_commerce_platform/pricing_options.rb
@@ -3,7 +3,7 @@
 module SolidusPaypalCommercePlatform
   class PricingOptions < Spree::Variant::PricingOptions
     def cache_key
-      SolidusPaypalCommercePlatform::PaymentMethod.active.map(&:cache_key).sort + [super]
+      SolidusPaypalCommercePlatform::PaymentMethod.active.map(&:cache_key_with_version).sort + [super]
     end
   end
 end


### PR DESCRIPTION
Previously the product cache would not update when you updated a
payment_method, this adds a version to cache_key so that happens.