### PR TITLE
Use options instead of preferences

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -18,7 +18,7 @@ module SolidusPaypalCommercePlatform
     end
 
     def display_on_cart
-      preferences[:display_on_cart]
+      options[:display_on_cart] || false
     end
 
     def cart_partial_name
@@ -26,7 +26,7 @@ module SolidusPaypalCommercePlatform
     end
 
     def display_on_product_page
-      preferences[:display_on_product_page]
+      options[:display_on_product_page] || false
     end
 
     def product_page_partial_name
@@ -34,11 +34,11 @@ module SolidusPaypalCommercePlatform
     end
 
     def client_id
-      preferences[:client_id]
+      options[:client_id]
     end
 
     def client_secret
-      preferences[:client_secret]
+      options[:client_secret]
     end
 
     def payment_source_class
@@ -51,10 +51,10 @@ module SolidusPaypalCommercePlatform
 
     def button_style
       {
-        color: preferences[:paypal_button_color],
-        size: preferences[:paypal_button_size],
-        shape: preferences[:paypal_button_shape],
-        layout: preferences[:paypal_button_layout]
+        color: options[:paypal_button_color] || "gold",
+        size: options[:paypal_button_size] || "responsive",
+        shape: options[:paypal_button_shape] || "rect",
+        layout: options[:paypal_button_layout] || "vertical"
       }
     end
 

--- a/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
+++ b/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
@@ -1,4 +1,4 @@
-<% if @payment_method.type == "SolidusPaypalCommercePlatform::PaymentMethod" && !@payment_method.preferences[:paypal_email_confirmed] %>
+<% if @payment_method.type == "SolidusPaypalCommercePlatform::PaymentMethod" && !@payment_method.options[:paypal_email_confirmed] %>
   <%= f.check_box :available_to_users, disabled: true %>
   <%= f.field_hint :available_to_users %>
 <% else %>


### PR DESCRIPTION
If the user is using a static preference model, `payment_method.preferences`
returns the static preference model instead of a hash of preferences.
`payment_method.options` always returns a hash of preferences, so we want to
use that instead.

Also adds some defaults for some of the preference getters, because if they
aren't specifically set in the static preference model, they will return
nil instead of the default value. This breaks frontend pages, so we're going to
return defaults instead.