### PR TITLE
Display capture_id instead of order_id to admin user

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
   hello: Hello world
   sign_up_for_paypal: Setup PayPal Commerce Platform
   start_paying_with_paypal: Start paying with Paypal Commerce Platform
-  paypal_order_id: PayPal Order ID
+  paypal_capture_id: PayPal Capture ID
   paypal_debug_id: PayPal Debug ID
   paypal_email: PayPal Email
   payment_email: "Payment Email: %{email}"

--- a/lib/views/backend/spree/admin/payments/source_views/_paypal_commerce_platform.html.erb
+++ b/lib/views/backend/spree/admin/payments/source_views/_paypal_commerce_platform.html.erb
@@ -7,8 +7,8 @@
         <dt><%= I18n.t("spree.identifier") %>:</dt>
         <dd><%= payment.number %></dd>
 
-        <dt><%= I18n.t("paypal_order_id") %>:</dt>
-        <dd><%= payment.source.paypal_order_id %></dd>
+        <dt><%= I18n.t("paypal_capture_id") %>:</dt>
+        <dd><%= payment.source.capture_id %></dd>
 
         <dt><%= I18n.t("paypal_email") %>:</dt>
         <dd><%= payment.source.paypal_email %></dd>


### PR DESCRIPTION
Per Hai, the order_id is useless to admin users - instead, they want
the capture_id. Thankfully we already store this ID, we just need to
display it. 

Fixed #69 