### PR TITLE
Return a payment declined error on the frontend

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/gateway.rb
+++ b/app/models/solidus_paypal_commerce_platform/gateway.rb
@@ -23,15 +23,19 @@ module SolidusPaypalCommercePlatform
       request = OrdersCaptureRequest.new(source.paypal_order_id)
       request.request_body(amount: { currency_code: options[:currency], value: Money.new(money).dollars })
       response = @client.execute_with_response(request)
-      capture_id = response.params["result"].purchase_units[0].payments.captures[0].id
-      source.update(capture_id: capture_id) if response.success?
+      if response.success?
+        capture_id = response.params["result"].purchase_units[0].payments.captures[0].id
+        source.update(capture_id: capture_id)
+      end
       response
     end
 
     def authorize(_money, source, _options)
       response = @client.execute_with_response(OrdersAuthorizeRequest.new(source.paypal_order_id))
-      authorization_id = response.params["result"].purchase_units.first.payments.authorizations.first.id
-      source.update(authorization_id: authorization_id) if response.success?
+      if response.success?
+        authorization_id = response.params["result"].purchase_units.first.payments.authorizations.first.id
+        source.update(authorization_id: authorization_id)
+      end
       response
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,10 @@ en:
     responses:
       pay_pal_checkout_sdk/orders/orders_capture_request:
         success: "Payment captured"
+        failure: "Your payment was declined - please try again using a different payment method."
       pay_pal_checkout_sdk/orders/orders_authorize_request:
         success: "Payment authorized"
+        failure: "Your payment was declined - please try again using a different payment method."
       pay_pal_checkout_sdk/payments/authorizations_capture_request:
         success: "Authorization captured"
       pay_pal_checkout_sdk/payments/captures_refund_request:


### PR DESCRIPTION
Previously, declined payments would cause an exception - this redirects the
user back to the payment page with an error that explains why.

Fixes #68 