### PR TITLE
Default available_to_users to true

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/wizard_controller.rb
@@ -32,7 +32,6 @@ module SolidusPaypalCommercePlatform
         preferred_client_id: api_credentials.client_id,
         preferred_client_secret: api_credentials.client_secret,
         preferred_test_mode: SolidusPaypalCommercePlatform.config.env.sandbox?,
-        available_to_users: false,
         available_to_admin: false
       }
     end

--- a/app/models/solidus_paypal_commerce_platform/payment_method.rb
+++ b/app/models/solidus_paypal_commerce_platform/payment_method.rb
@@ -11,7 +11,6 @@ module SolidusPaypalCommercePlatform
     preference :paypal_button_layout, :paypal_select, default: "vertical"
     preference :display_on_cart, :boolean, default: true
     preference :display_on_product_page, :boolean, default: true
-    preference :paypal_email_confirmed, :boolean, default: false
 
     def partial_name
       "paypal_commerce_platform"

--- a/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
+++ b/app/views/solidus_paypal_commerce_platform/admin/payment_methods/_available_to_users.html.erb
@@ -1,5 +1,5 @@
-<% if @payment_method.type == "SolidusPaypalCommercePlatform::PaymentMethod" && !@payment_method.options[:paypal_email_confirmed] %>
-  <%= f.check_box :available_to_users, disabled: true %>
+<% if @payment_method.type == "SolidusPaypalCommercePlatform::PaymentMethod" %>
+  <%= f.check_box :available_to_users %>
   <%= f.field_hint :available_to_users %>
 <% else %>
   <%= f.check_box :available_to_users %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   spree:
     hints:
       solidus_paypal_commerce_platform/payment_method:
-        available_to_users: You must verify that your email is confirmed with PayPal before allowing users to check out.
+        available_to_users: You must verify that your email is confirmed with PayPal before users will be able to check out with this payment method.
     payment_source: source
   activerecord:
     attributes:


### PR DESCRIPTION
Removes the paypal_email_verified check, and instead always displays
an info icon notifying the admin users that they need to have their
email verified before users can successfully check out.

Fixed #71 