### PR TITLE
Add overlay to ease transition to confirmation page

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
+++ b/app/assets/javascripts/spree/frontend/solidus_paypal_commerce_platform/button_actions.js
@@ -1,3 +1,11 @@
+SolidusPaypalCommercePlatform.showOverlay = function() {
+  document.getElementById("paypal_commerce_platform_overlay").style.display = "block";
+}
+
+SolidusPaypalCommercePlatform.hideOverlay = function() {
+  document.getElementById("paypal_commerce_platform_overlay").style.display = "none";
+}
+
 SolidusPaypalCommercePlatform.sendOrder = function(payment_method_id) {
   return Spree.ajax({
     url: '/solidus_paypal_commerce_platform/paypal_orders/' + Spree.current_order_id,
@@ -62,6 +70,7 @@ SolidusPaypalCommercePlatform.getQuantity = function() {
 }
 
 SolidusPaypalCommercePlatform.approveOrder = function(data, actions) {
+  SolidusPaypalCommercePlatform.showOverlay()
   actions.order.get().then(function(response){
     SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
       SolidusPaypalCommercePlatform.verifyTotal(response.purchase_units[0].amount.value).then(function(){
@@ -102,12 +111,14 @@ SolidusPaypalCommercePlatform.verifyTotal = function(paypal_total) {
       paypal_total: paypal_total
     },
     error: function(response) {
+      SolidusPaypalCommercePlatform.hideOverlay()
       alert('There were some problems with your payment - ' + response.responseJSON.errors.expected_total);
     }
   })
 }
 
 SolidusPaypalCommercePlatform.finalizeOrder = function(payment_method_id, data, actions) {
+  SolidusPaypalCommercePlatform.showOverlay()
   actions.order.get().then(function(response){
     SolidusPaypalCommercePlatform.updateAddress(response).then(function() {
       var paypal_amount = response.purchase_units[0].amount.value
@@ -130,6 +141,7 @@ SolidusPaypalCommercePlatform.advanceOrder = function() {
       order_token: Spree.current_order_token
     },
     error: function(response) {
+      SolidusPaypalCommercePlatform.hideOverlay()
       alert('There were some problems with your order');
     }
   })
@@ -151,6 +163,7 @@ SolidusPaypalCommercePlatform.addPayment = function(paypal_amount, payment_metho
       }
     },
     error: function(response) {
+      SolidusPaypalCommercePlatform.hideOverlay()
       alert('There were some problems with your payment');
     }
   })
@@ -170,6 +183,7 @@ SolidusPaypalCommercePlatform.updateAddress = function(response) {
       order_token: Spree.current_order_token
     },
     error: function(response) {
+      SolidusPaypalCommercePlatform.hideOverlay()
       message = response.responseJSON;
       alert('There were some problems with your payment address - ' + message);
     }

--- a/app/assets/stylesheets/spree/frontend/solidus_paypal_commerce_platform.css
+++ b/app/assets/stylesheets/spree/frontend/solidus_paypal_commerce_platform.css
@@ -2,3 +2,16 @@
 Placeholder manifest file.
 the installer will append this file to the app vendored assets here: 'vendor/assets/stylesheets/spree/frontend/all.css'
 */
+
+#paypal_commerce_platform_overlay{
+  position: fixed;
+  display: none;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 100;
+}

--- a/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/checkout/payment/_paypal_commerce_platform.html.erb
@@ -9,3 +9,5 @@
     SolidusPaypalCommercePlatform.renderButton("<%= payment_method.id %>",<%= raw payment_method.button_style.to_json %>)
   })
 </script>
+
+<div id="paypal_commerce_platform_overlay"></div>

--- a/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/orders/payment/_paypal_commerce_platform.html.erb
@@ -13,3 +13,5 @@
     })
   </script>
 </div>
+
+<div id="paypal_commerce_platform_overlay"></div>

--- a/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
+++ b/lib/views/frontend/spree/products/payment/_paypal_commerce_platform.html.erb
@@ -11,3 +11,5 @@
     })
   </script>
 </div>
+
+<div id="paypal_commerce_platform_overlay"></div>


### PR DESCRIPTION
The transition to payment page can take a second, and in that time
the user is on the Solidus app, able to click on things and navigate
away. This adds an overlay to the page that prevents any misclicks
during this time.

Fixes #63 