### PR TITLE
Change outstanding_balance to total in order total checker

### DIFF
--- a/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
+++ b/app/controllers/solidus_paypal_commerce_platform/orders_controller.rb
@@ -47,7 +47,7 @@ module SolidusPaypalCommercePlatform
     private
 
     def total_is_correct?(paypal_total)
-      @order.outstanding_balance == BigDecimal(paypal_total)
+      @order.total == BigDecimal(paypal_total)
     end
 
     def paypal_address_params


### PR DESCRIPTION
Previously we were checking PayPals total against the orders
outstanding balance, however if the outstanding balance is
different than the order total, this check would never pass
because we send PayPal the whole order. Changing this to total
instead is a bit more clear and provides less room for errors.