### PR TITLE
Send line_item and shipping promotions to PayPal

### DIFF
--- a/app/models/solidus_paypal_commerce_platform/paypal_order.rb
+++ b/app/models/solidus_paypal_commerce_platform/paypal_order.rb
@@ -93,7 +93,7 @@ module SolidusPaypalCommercePlatform
         item_total: price(@order.item_total),
         shipping: price(@order.shipment_total),
         tax_total: price(@order.additional_tax_total),
-        discount: price(@order.adjustments.sum(&:amount))
+        discount: price(@order.all_adjustments.promotion.sum(&:amount).abs)
       }
     end
 


### PR DESCRIPTION
This allows us to send all promotions to PayPal, not just order adjustments.
Previously, any line_item or shipping promotions would not be sent, the order
total would not add up, and PayPal would complain.