### PR TITLE
Add a configurable state_guesser class to guess states

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ end
 
 The instances of your wizard class should respond to `#name` and `#partial_name`, where `partial_name` will return the path to the partial you'd like to display on the wizard setup section. In our case, we just display a button to direct the user to PayPal.
 
+## State Guesser
+PayPal users can change their shipping address directly on PayPal, which will
+update their address on Solidus as well. However, in some instances, Solidus
+uses the incorrect subregion level for states, which causes validation problems
+with the addresses that PayPal sends to us.
+
+For instance, if your user lives in Pescara, Italy, then PayPal will return
+"Pescara" as the state. However on older version of Solidus, the region
+"Abruzzo" is used, so the address will not be able to validate. To solve this
+issue, we've implented a class that attempts to guess the state of the user
+using Carmen subregions if the state cannot be initially found. You can, of
+course, implement your own state guesser and set it like this:
+
+```ruby
+# config/initializers/use_my_guesser.rb
+SolidusPaypalCommercePlatform.configure do |config|
+  config.state_guesser_class = "MyApp::MyStateGuesser"
+end
+```
+
 ## Custom Checkout Steps
 
 With product and cart page checkout, the user is directed to the checkout confirmation step when they return from PayPal. If you've removed the confirmation step, you'll need to override the `SolidusPaypalCommercePlatform.finalizeOrder` JavaScript method to instead complete the order.

--- a/app/models/solidus_paypal_commerce_platform/state_guesser.rb
+++ b/app/models/solidus_paypal_commerce_platform/state_guesser.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module SolidusPaypalCommercePlatform
+  class StateGuesser
+    def initialize(state_name, country)
+      @state_name = state_name
+      @country = country
+    end
+
+    def guess
+      carmen_state = state_list.find{ |s| s.name == @state_name || s.code == @state_name }
+      return if carmen_state.blank?
+
+      guessed_state = spree_state(carmen_state.name)
+      guessed_state || spree_state(carmen_state.parent.name)
+    end
+
+    private
+
+    def state_list
+      Carmen::Country.coded(@country.iso).subregions.map{ |s| [s, s.subregions] }.flatten
+    end
+
+    def spree_state(name)
+      Spree::State.find_by(name: name)
+    end
+  end
+end

--- a/lib/solidus_paypal_commerce_platform/configuration.rb
+++ b/lib/solidus_paypal_commerce_platform/configuration.rb
@@ -4,6 +4,7 @@ require 'paypal-checkout-sdk'
 
 module SolidusPaypalCommercePlatform
   class Configuration
+    attr_writer :state_guesser_class
     InvalidEnvironment = Class.new(StandardError)
 
     DEFAULT_PARTNER_ID = {
@@ -15,6 +16,12 @@ module SolidusPaypalCommercePlatform
       sandbox: "ATDpQjHzjCz_C_qbbJ76Ca0IjcmwlS4FztD6YfuRFZXDCmcWWw8-8QWcF3YIkbC85ixTUuuSEvrBMVSX",
       live: "ASOxaUMkeX5bv7PbXnWUDnqb3SVYkzRSosApmLGFih-eAhB_OS_Wo6juijE5t8NCmWDgpN2ugHMmQFWA",
     }.freeze
+
+    def state_guesser_class
+      self.state_guesser_class = "SolidusPaypalCommercePlatform::StateGuesser" unless @state_guesser_class
+
+      @state_guesser_class.constantize
+    end
 
     def env=(value)
       unless %w[live sandbox].include? value

--- a/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
+++ b/spec/lib/solidus_paypal_commerce_platform/configuration_spec.rb
@@ -64,4 +64,22 @@ RSpec.describe SolidusPaypalCommercePlatform::Configuration do
       expect(subject.env_domain).to eq("www.sandbox.paypal.com")
     end
   end
+
+  describe "#state_guesser_class" do
+    before do
+      stub_const('SolidusPaypalCommercePlatform::BetterStateGuesser', Class.new)
+    end
+
+    it "returns a class" do
+      expect(subject.state_guesser_class).to be_kind_of(Class)
+    end
+
+    it "is settable" do
+      expect(subject.state_guesser_class).to eq(SolidusPaypalCommercePlatform::StateGuesser)
+
+      subject.state_guesser_class = "SolidusPaypalCommercePlatform::BetterStateGuesser"
+
+      expect(subject.state_guesser_class).to eq(SolidusPaypalCommercePlatform::BetterStateGuesser)
+    end
+  end
 end

--- a/spec/models/solidus_paypal_commerce_platform/state_guesser_spec.rb
+++ b/spec/models/solidus_paypal_commerce_platform/state_guesser_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe SolidusPaypalCommercePlatform::StateGuesser, type: :model do
+  let(:country) { create(:country, iso: "IT") }
+  let!(:state) { create(:state, country: country, name: "Abruzzo") }
+
+  describe "#guess" do
+    context "with a guessable state error" do
+      it "correctly guesses the state" do
+        expect(
+          described_class.new("Pescara", country).guess
+        ).to eq state
+      end
+
+      it "guesses the state using an abbreviation" do
+        expect(
+          described_class.new("PE", country).guess
+        ).to eq state
+      end
+    end
+
+    context "with an unsolvable state error" do
+      it "returns nil" do
+        expect(
+          described_class.new("Gondor", country).guess
+        ).to eq nil
+      end
+    end
+
+    context "with an already correct state" do
+      it "returns the correct state" do
+        expect(
+          described_class.new("Abruzzo", country).guess
+        ).to eq state
+      end
+    end
+  end
+end


### PR DESCRIPTION
Solidus in some cases uses the incorrect states for a country - for instance,
Solidus uses the first level of subregions in Carmen for Italy, while it
actually needs to use the second level of subregions. This causes issues
with this extension, as if the PayPal address a user has is in Italy - or
one of the other states with this issue - the address validation will fail,
and PayPal will tell the user that we don't ship to that area, essentially
preventing checkout in these cases.

This adds a state guesser class that attemps to help in those situations by
finding the Carmen region, and returning the regions parent region, which
should match the Solidus state on file. I'm not sure if this will work in
every country with this issue, but it at least solves the issue with Italy.